### PR TITLE
syntax: add `caddyfile-test`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Added
+
+- Added support for the `.caddyfiletest` file extension ([#299](https://github.com/caddyserver/vscode-caddyfile/issues/299))
+
 ### Fixed
 
 - Updated placeholder regex to support `[]` notation for accessing array elements ([#298](https://github.com/caddyserver/vscode-caddyfile/issues/298))

--- a/examples/acme_server_lifetime.caddyfiletest
+++ b/examples/acme_server_lifetime.caddyfiletest
@@ -1,0 +1,108 @@
+{
+	pki {
+		ca internal {
+			name "Internal"
+			root_cn "Internal Root Cert"
+			intermediate_cn "Internal Intermediate Cert"
+		}
+		ca internal-long-lived {
+			name "Long-lived"
+			root_cn "Internal Root Cert 2"
+			intermediate_cn "Internal Intermediate Cert 2"
+		}
+	}
+}
+
+acme-internal.example.com {
+	acme_server {
+		ca internal
+	}
+}
+
+acme-long-lived.example.com {
+	acme_server {
+		ca internal-long-lived
+		lifetime 7d
+	}
+}
+----------
+{
+	"apps": {
+		"http": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":443"
+					],
+					"routes": [
+						{
+							"match": [
+								{
+									"host": [
+										"acme-long-lived.example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"ca": "internal-long-lived",
+													"handler": "acme_server",
+													"lifetime": 604800000000000
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						},
+						{
+							"match": [
+								{
+									"host": [
+										"acme-internal.example.com"
+									]
+								}
+							],
+							"handle": [
+								{
+									"handler": "subroute",
+									"routes": [
+										{
+											"handle": [
+												{
+													"ca": "internal",
+													"handler": "acme_server"
+												}
+											]
+										}
+									]
+								}
+							],
+							"terminal": true
+						}
+					]
+				}
+			}
+		},
+		"pki": {
+			"certificate_authorities": {
+				"internal": {
+					"name": "Internal",
+					"root_common_name": "Internal Root Cert",
+					"intermediate_common_name": "Internal Intermediate Cert"
+				},
+				"internal-long-lived": {
+					"name": "Long-lived",
+					"root_common_name": "Internal Root Cert 2",
+					"intermediate_common_name": "Internal Intermediate Cert 2"
+				}
+			}
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,111 +1,127 @@
 {
-    "name": "caddyfile-support",
-    "displayName": "Caddyfile Support",
-    "description": "Rich Caddyfile support for Visual Studio Code",
-    "version": "0.3.0",
-    "license": "MIT",
-    "private": true,
-    "main": "packages/client/dist/index.js",
-    "packageManager": "pnpm@8.5.0",
-    "icon": "media/caddy-logo.png",
-    "categories": [
-        "Programming Languages",
-        "Linters",
-        "Formatters"
-    ],
-    "publisher": "matthewpi",
-    "author": {
-        "name": "Caddy Team"
-    },
-    "repository": {
-        "type": "git",
+	"name": "caddyfile-support",
+	"displayName": "Caddyfile Support",
+	"description": "Rich Caddyfile support for Visual Studio Code",
+	"version": "0.3.0",
+	"license": "MIT",
+	"private": true,
+	"main": "packages/client/dist/index.js",
+	"packageManager": "pnpm@8.5.0",
+	"icon": "media/caddy-logo.png",
+	"categories": [
+		"Programming Languages",
+		"Linters",
+		"Formatters"
+	],
+	"publisher": "matthewpi",
+	"author": {
+		"name": "Caddy Team"
+	},
+	"repository": {
+		"type": "git",
 		"url": "https://github.com/caddyserver/vscode-caddyfile"
-    },
-    "bugs": {
-        "url": "https://github.com/caddyserver/vscode-caddyfile/issues"
-    },
-    "engines": {
-        "node": ">=16.13.0",
-        "vscode": ">=1.67.0"
-    },
-    "scripts": {
-        "vscode:prepublish": "pnpm run build",
+	},
+	"bugs": {
+		"url": "https://github.com/caddyserver/vscode-caddyfile/issues"
+	},
+	"engines": {
+		"node": ">=16.13.0",
+		"vscode": ">=1.67.0"
+	},
+	"scripts": {
+		"vscode:prepublish": "pnpm run build",
 		"package": "mkdir dist; pnpm vsce package --no-dependencies --no-yarn --out dist/caddyfile-support.vsix",
-        "build": "turbo run build",
-        "dev": "turbo run dev --no-cache --parallel --continue",
-        "lint": "turbo run lint",
-        "clean": "turbo run clean && rimraf node_modules/.cache"
-    },
-    "devDependencies": {
+		"build": "turbo run build",
+		"dev": "turbo run dev --no-cache --parallel --continue",
+		"lint": "turbo run lint",
+		"clean": "turbo run clean && rimraf node_modules/.cache"
+	},
+	"devDependencies": {
 		"@vscode/vsce": "2.19.0",
-        "prettier": "2.8.8",
-        "rimraf": "5.0.0",
-        "turbo": "1.9.6",
-        "typescript": "5.0.4"
-    },
-    "extensionDependencies": [],
-    "activationEvents": [
-        "onLanguage:caddyfile",
-        "workspaceContains:**/Caddyfile",
-        "workspaceContains:**/Caddyfile*",
-        "workspaceContains:**/caddyfile",
-        "workspaceContains:**/caddyfile*",
-        "workspaceContains:**/*.Caddyfile",
-        "workspaceContains:**/*.caddyfile"
-    ],
-    "contributes": {
-        "languages": [
-            {
-                "id": "caddyfile",
-                "configuration": "./language-configuration.json",
-                "aliases": [
-                    "Caddyfile",
-                    "Caddy",
-                    "caddyfile",
-                    "caddy"
-                ],
-                "extensions": [
-                    "Caddyfile",
-                    "Caddyfile*",
-                    "caddyfile",
-                    "caddyfile*",
-                    "*.Caddyfile",
-                    "*.caddyfile"
-                ]
-            }
-        ],
-        "grammars": [
-            {
-                "language": "caddyfile",
-                "scopeName": "source.Caddyfile",
-                "path": "./syntaxes/caddyfile.tmLanguage.json"
-            },
-            {
-                "scopeName": "source.markdown.caddy.codeblock",
-                "path": "./syntaxes/caddy-markdown.tmLanguage.json",
-                "injectTo": [
-                    "text.html.markdown"
-                ],
-                "embeddedLanguages": {
-                    "meta.embedded.block.caddy": "caddyfile"
-                }
-            }
-        ],
-        "configurationDefaults": {
-            "[caddyfile]": {
-                "editor.insertSpaces": false,
-                "editor.formatOnSave": true
-            }
-        },
-        "configuration": {
-            "title": "Caddyfile",
-            "properties": {
-                "caddyfile.executable": {
-                    "type": "string",
-                    "default": "",
-                    "description": "Location of the `caddy` executable to use for code formatting and linting."
-                }
-            }
-        }
-    }
+		"prettier": "2.8.8",
+		"rimraf": "5.0.0",
+		"turbo": "1.9.6",
+		"typescript": "5.0.4"
+	},
+	"extensionDependencies": [],
+	"activationEvents": [
+		"onLanguage:caddyfile",
+		"workspaceContains:**/Caddyfile",
+		"workspaceContains:**/Caddyfile*",
+		"workspaceContains:**/caddyfile",
+		"workspaceContains:**/caddyfile*",
+		"workspaceContains:**/*.Caddyfile",
+		"workspaceContains:**/*.caddyfile"
+	],
+	"contributes": {
+		"languages": [
+			{
+				"id": "caddyfile",
+				"configuration": "./language-configuration.json",
+				"aliases": [
+					"Caddyfile",
+					"Caddy",
+					"caddyfile",
+					"caddy"
+				],
+				"extensions": [
+					"Caddyfile",
+					"Caddyfile*",
+					"caddyfile",
+					"caddyfile*",
+					"*.Caddyfile",
+					"*.caddyfile"
+				]
+			},
+			{
+				"id": "caddyfile-test",
+				"configuration": "./language-configuration.json",
+				"aliases": [
+					"Caddyfile-test"
+				],
+				"extensions": [
+					"*.Caddyfiletest",
+					"*.caddyfiletest"
+				]
+			}
+		],
+		"grammars": [
+			{
+				"language": "caddyfile",
+				"scopeName": "source.Caddyfile",
+				"path": "./syntaxes/caddyfile.tmLanguage.json"
+			},
+			{
+				"language": "caddyfile-test",
+				"scopeName": "source.Caddyfile-test",
+				"path": "./syntaxes/caddyfile-test.tmLanguage.json"
+			},
+			{
+				"scopeName": "source.markdown.caddy.codeblock",
+				"path": "./syntaxes/caddy-markdown.tmLanguage.json",
+				"injectTo": [
+					"text.html.markdown"
+				],
+				"embeddedLanguages": {
+					"meta.embedded.block.caddy": "caddyfile"
+				}
+			}
+		],
+		"configurationDefaults": {
+			"[caddyfile]": {
+				"editor.insertSpaces": false,
+				"editor.formatOnSave": true
+			}
+		},
+		"configuration": {
+			"title": "Caddyfile",
+			"properties": {
+				"caddyfile.executable": {
+					"type": "string",
+					"default": "",
+					"description": "Location of the `caddy` executable to use for code formatting and linting."
+				}
+			}
+		}
+	}
 }

--- a/syntaxes/caddy-markdown.tmLanguage.json
+++ b/syntaxes/caddy-markdown.tmLanguage.json
@@ -4,10 +4,7 @@
 	"scopeName": "source.markdown.caddy.codeblock",
 	"injectionSelector": "L:text.html.markdown",
 
-	"patterns": [
-		{ "include": "#caddy-code-block" },
-		{ "include": "#caddy-d-code-block" }
-	],
+	"patterns": [{ "include": "#caddy-code-block" }, { "include": "#caddy-d-code-block" }],
 
 	"repository": {
 		"caddy-code-block": {
@@ -42,9 +39,7 @@
 					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
 					"contentName": "meta.embedded.block.caddy",
 
-					"patterns": [
-						{ "include": "source.Caddyfile" }
-					]
+					"patterns": [{ "include": "source.Caddyfile" }]
 				}
 			]
 		},
@@ -80,9 +75,7 @@
 					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
 					"contentName": "meta.embedded.block.caddy",
 
-					"patterns": [
-						{ "include": "source.Caddyfile#block_content" }
-					]
+					"patterns": [{ "include": "source.Caddyfile#block_content" }]
 				}
 			]
 		}

--- a/syntaxes/caddyfile-test.tmLanguage.json
+++ b/syntaxes/caddyfile-test.tmLanguage.json
@@ -1,0 +1,37 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+
+	"name": "Caddyfile-test",
+	"fileTypes": ["Caddyfile-test"],
+	"scopeName": "source.Caddyfile-test",
+
+	"patterns": [
+		{ "include": "#json" },
+		{ "include": "source.Caddyfile" }
+	],
+
+	"repository": {
+		"json": {
+			"patterns": [
+				{
+					"name": "meta.embedded.json",
+					"contentName": "source.json",
+
+					"begin": "^(-{10})$",
+					"beginCaptures": {
+						"0": { "name": "punctuation.section.embedded.start.json" }
+					},
+
+					"end": "^(\\})$",
+					"endCaptures": {
+						"0": { "name": "punctuation.section.embedded.start.json" }
+					},
+
+					"patterns": [
+						{ "include": "source.json" }
+					]
+				}
+			]
+		}
+	}
+}

--- a/syntaxes/caddyfile.tmLanguage.json
+++ b/syntaxes/caddyfile.tmLanguage.json
@@ -67,7 +67,7 @@
 			"patterns": [
 				{
 					"name": "keyword.control.caddyfile",
-					"match": "(unix\/)*\/[a-zA-Z0-9_\\-./*]+"
+					"match": "(unix/)*/[a-zA-Z0-9_\\-./*]+"
 				},
 				{
 					"name": "variable.other.property.caddyfile",
@@ -75,11 +75,11 @@
 				},
 				{
 					"name": "variable.other.property.caddyfile",
-					"match": "\\*\/?"
+					"match": "\\*/?"
 				},
 				{
 					"name": "variable.other.property.caddyfile",
-					"match": "\\?\/"
+					"match": "\\?/"
 				}
 			]
 		},
@@ -89,7 +89,7 @@
 				{
 					"comment": "Domains and URLs",
 					"name": "keyword.control.caddyfile",
-					"match": "(https?:\/\/)*[a-z0-9-\\*]*(?:\\.[a-zA-Z]{2,})+(:[0-9]+)*\\S*"
+					"match": "(https?://)*[a-z0-9-\\*]*(?:\\.[a-zA-Z]{2,})+(:[0-9]+)*\\S*"
 				},
 				{
 					"comment": "localhost",
@@ -140,10 +140,7 @@
 		},
 
 		"site_block_common": {
-			"patterns": [
-				{ "include": "#placeholders" },
-				{ "include": "#block" }
-			]
+			"patterns": [{ "include": "#placeholders" }, { "include": "#block" }]
 		},
 
 		"matchers": {
@@ -181,7 +178,7 @@
 				{
 					"comment": "Content Types",
 					"name": "variable.other.property.caddyfile",
-					"match": "(application|audio|example|font|image|message|model|multipart|text|video)\/[a-zA-Z0-9*+\\-.]+;* *[a-zA-Z0-9=\\-]*"
+					"match": "(application|audio|example|font|image|message|model|multipart|text|video)/[a-zA-Z0-9*+\\-.]+;* *[a-zA-Z0-9=\\-]*"
 				}
 			]
 		},
@@ -192,9 +189,7 @@
 					"begin": "\\{",
 					"end": "\\}",
 
-					"patterns": [
-						{ "include": "#block_content" }
-					]
+					"patterns": [{ "include": "#block_content" }]
 				}
 			]
 		},
@@ -223,9 +218,7 @@
 					"begin": "(?i)(?=<<\\s*([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)\\s*$)",
 					"end": "(?!\\G)",
 					"name": "string.unquoted.heredoc.caddyfile",
-					"patterns": [
-						{ "include": "#heredoc_interior" }
-					]
+					"patterns": [{ "include": "#heredoc_interior" }]
 				}
 			]
 		},
@@ -252,9 +245,7 @@
 						"1": { "name": "keyword.operator.heredoc.caddyfile" }
 					},
 
-					"patterns": [
-						{ "include": "source.css" }
-					]
+					"patterns": [{ "include": "source.css" }]
 				},
 
 				{
@@ -277,9 +268,7 @@
 						"1": { "name": "keyword.operator.heredoc.caddyfile" }
 					},
 
-					"patterns": [
-						{ "include": "text.html.basic" }
-					]
+					"patterns": [{ "include": "text.html.basic" }]
 				},
 
 				{
@@ -302,9 +291,7 @@
 						"1": { "name": "keyword.operator.heredoc.caddyfile" }
 					},
 
-					"patterns": [
-						{ "include": "source.js" }
-					]
+					"patterns": [{ "include": "source.js" }]
 				},
 
 				{
@@ -327,9 +314,7 @@
 						"1": { "name": "keyword.operator.heredoc.caddyfile" }
 					},
 
-					"patterns": [
-						{ "include": "source.json" }
-					]
+					"patterns": [{ "include": "source.json" }]
 				},
 
 				{
@@ -352,9 +337,7 @@
 						"1": { "name": "keyword.operator.heredoc.caddyfile" }
 					},
 
-					"patterns": [
-						{ "include": "text.xml" }
-					]
+					"patterns": [{ "include": "text.xml" }]
 				},
 
 				{


### PR DESCRIPTION
This took longer than I expected to write, the solution was so simple but I just had to make it difficult for myself.

Utilizes a new `.caddyfiletest` (or `.Caddyfiletest`) file extension.

The grammar works by looking for `^-{10}$` (10 `-` characters in a row on a line by themselves, no preceding or trailing white-space will be accepted), after that an embedded JSON section is enabled until an un-indented closing bracket (`}`) is found.

Closes #299

/cc @francislavoie @mholt 